### PR TITLE
Implement OpenSprinkler host resolver class

### DIFF
--- a/custom_components/device_pulse/host_resolvers/opensprinkler.py
+++ b/custom_components/device_pulse/host_resolvers/opensprinkler.py
@@ -1,0 +1,13 @@
+import logging
+
+from .base import BaseHostResolver
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import device_registry as dr
+
+_LOGGER = logging.getLogger(__name__)
+
+class OpenSprinklerResolver(BaseHostResolver):
+    @staticmethod
+    def resolve(config_entry: ConfigEntry, device: dr.DeviceEntry) -> str | None:
+        return BaseHostResolver.device_configuration_url(device)


### PR DESCRIPTION
This allows users to select the OpenSprinkler device when configuring hosts to check.