### PR TITLE
Implement host resolvers for Jellyfin, PiHole and qBittorrent

### DIFF
--- a/custom_components/device_pulse/host_resolvers/jellyfin.py
+++ b/custom_components/device_pulse/host_resolvers/jellyfin.py
@@ -1,0 +1,22 @@
+import logging
+from urllib.parse import urlparse
+
+from .base import BaseHostResolver
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import device_registry as dr
+
+_LOGGER = logging.getLogger(__name__)
+
+class JellyfinResolver(BaseHostResolver):
+    @staticmethod
+    def resolve(config_entry: ConfigEntry, device: dr.DeviceEntry) -> str | None:
+        url = config_entry.data.get("url", None)
+        parsed = urlparse(url)
+
+        if (host := parsed.hostname):
+            _LOGGER.debug("Found Host [%s] for Jellyfin device [%s]", host, device.name)
+            return host
+
+        _LOGGER.debug("Found URL [%s] for Jellyfin device [%s], but wasn't able to retrieve host from it", url, device.name)
+        return None

--- a/custom_components/device_pulse/host_resolvers/pi_hole.py
+++ b/custom_components/device_pulse/host_resolvers/pi_hole.py
@@ -1,0 +1,13 @@
+import logging
+
+from .base import BaseHostResolver
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import device_registry as dr
+
+_LOGGER = logging.getLogger(__name__)
+
+class PiHoleResolver(BaseHostResolver):
+    @staticmethod
+    def resolve(config_entry: ConfigEntry, device: dr.DeviceEntry) -> str | None:
+        return BaseHostResolver.device_configuration_url(device)

--- a/custom_components/device_pulse/host_resolvers/qbittorrent.py
+++ b/custom_components/device_pulse/host_resolvers/qbittorrent.py
@@ -1,0 +1,22 @@
+import logging
+from urllib.parse import urlparse
+
+from .base import BaseHostResolver
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import device_registry as dr
+
+_LOGGER = logging.getLogger(__name__)
+
+class QbittorrentResolver(BaseHostResolver):
+    @staticmethod
+    def resolve(config_entry: ConfigEntry, device: dr.DeviceEntry) -> str | None:
+        url = config_entry.data.get("url", None)
+        parsed = urlparse(url)
+
+        if (host := parsed.hostname):
+            _LOGGER.debug("Found Host [%s] for qBittorrent device [%s]", host, device.name)
+            return host
+
+        _LOGGER.debug("Found URL [%s] for qBittorrent device [%s], but wasn't able to retrieve host from it", url, device.name)
+        return None


### PR DESCRIPTION
This PR adds the necessary host resolvers to allow the monitoring of some of the services I use and monitor through Home Assistant.

This has been tested on my own Home Assistant instance for validation:

<img width="1029" height="731" alt="image" src="https://github.com/user-attachments/assets/875aa0d0-8002-4110-b7cf-11d17d28401c" />

Not sure how we feel about adding services to Device Pulse, but those are all targeting a different VM or host on my newtork and having them linked to their respective integration seems fair to me.

This is mostly important for PiHole in my case as those are usually fully dedicated devices which I was previously tracking through the `Ping (ICMP)` integration. On the other hand, Jellyfin and qBittorrent are part of a bigger set of services on a specific host in my case, so I would understand if you would be against adding these resolvers.

Fixes #35.