### PR TITLE
fix: memory leak / resource accumulation when a reload starts

### DIFF
--- a/custom_components/device_pulse/__init__.py
+++ b/custom_components/device_pulse/__init__.py
@@ -1,6 +1,7 @@
 """Device Pulse Integration."""
 
 import asyncio
+import contextlib
 from dataclasses import dataclass, field
 from functools import partial
 import logging
@@ -8,10 +9,15 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntryChange
-from homeassistant.components.ping import PingDataICMPLib, PingDataSubProcess, _can_use_icmp_lib_with_privilege
+from homeassistant.config_entries import (
+    SIGNAL_CONFIG_ENTRY_CHANGED,
+    ConfigEntry,
+    ConfigEntryChange,
+    ConfigEntryState,
+)
+from homeassistant.components.ping import PingDataICMPLib, _can_use_icmp_lib_with_privilege
+from .ping_clients import ReapingPingDataSubProcess
 from homeassistant.components import zeroconf
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_DEVICE_ID,
@@ -358,10 +364,13 @@ async def async_setup_entry(
         _LOGGER.info("[%s]   Device Offline Log Level: %s",integration.friendly_name, logging.getLevelName(log_level_device_offline))
         _LOGGER.info("[%s] Found [%d] valid devices", integration.friendly_name, len(devices))
 
-        # Determine the ICMP ping client based on method and privileges
-        ping_icmp: type[PingDataICMPLib | PingDataSubProcess]
+        # Determine the ICMP ping client based on method and privileges.
+        # Use ReapingPingDataSubProcess (instead of the core PingDataSubProcess)
+        # when pinging via the subprocess so that the child "ping" process is
+        # killed when the refresh task gets cancelled on unload/reload/shutdown.
+        ping_icmp: type[PingDataICMPLib | ReapingPingDataSubProcess]
         ping_icmp_privileged = hass.data[DATA_CONFIG_KEY].ping_icmp_privileged
-        ping_icmp = PingDataSubProcess if ping_icmp_privileged is None else PingDataICMPLib
+        ping_icmp = ReapingPingDataSubProcess if ping_icmp_privileged is None else PingDataICMPLib
 
         ping_arp: type[PingDataARP] | None = None
         if ping_method == PING_METHOD_ARP:
@@ -649,18 +658,32 @@ async def _device_registry_updated(
     if reload:
         _LOGGER.info("[%s] Reloading config entry", integration.friendly_name)
         config_entry = hass.config_entries.async_get_entry(monitored[integration.domain].config_entry_id)
+        if config_entry is None:
+            return
 
-        # Prevent multiple reloads
+        # Prevent multiple reloads. The task is created as a config entry
+        # background task so that the core cancels it automatically when the
+        # entry is unloaded (during a reload/restart). This avoids a stale
+        # reload firing against an already unloaded entry.
         if config_entry.runtime_data.reload_task:
             config_entry.runtime_data.reload_task.cancel()
 
         # Schedule reload with a small delay
         async def delayed_reload() -> None:
             await asyncio.sleep(2)
+            # Skip the reload if the entry is no longer loaded (e.g. the
+            # entry was removed/disabled or HA is shutting down meanwhile).
+            if hass.is_stopping or config_entry.state != ConfigEntryState.LOADED:
+                return
             await hass.config_entries.async_reload(config_entry.entry_id)
             _LOGGER.info("[%s] Config entry reloaded!", integration.friendly_name)
 
-        config_entry.runtime_data.reload_task = hass.async_create_task(delayed_reload())
+        config_entry.runtime_data.reload_task = config_entry.async_create_background_task(
+            hass,
+            delayed_reload(),
+            name=f"Device Pulse reload {integration.friendly_name}",
+            eager_start=True,
+        )
 
 
 async def _state_changed(
@@ -718,6 +741,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if entry.data.get(CONF_ENTRY_TYPE) == ENTRY_TYPE_INTEGRATION:
         domain = entry.data.get(CONF_INTEGRATION)
         hass.data[DATA_CONFIG_KEY].monitored.pop(domain)
+
+    # Cancel any pending reload task so it does not fire against an entry that
+    # is being (or has just been) unloaded.
+    reload_task = getattr(entry, "runtime_data", None) and entry.runtime_data.reload_task
+    if reload_task:
+        entry.runtime_data.reload_task = None
+        reload_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reload_task
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 

--- a/custom_components/device_pulse/arping.py
+++ b/custom_components/device_pulse/arping.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 import logging
 from typing import Any
 
@@ -37,6 +38,7 @@ class PingDataARP:
         # -I: interface
         cmd = ["arping", "-f", "-c", str(self.count), "-I", self._adapter.get("name"), self.ip_address]
 
+        process = None
         try:
             process = await asyncio.create_subprocess_exec(
                 *cmd,
@@ -66,6 +68,19 @@ class PingDataARP:
             self.is_alive = False
             self.data = None
             _LOGGER.debug("ARP ping to %s timed out", self.ip_address)
+            # Make sure the arping child is reaped after the timeout
+            if process is not None and process.returncode is None:
+                with suppress(TypeError, ProcessLookupError):
+                    process.kill()
+        except asyncio.CancelledError:
+            # The refresh task was cancelled (e.g. config entry unload/reload
+            # or shutdown): kill the arping child instead of leaking it.
+            self.is_alive = False
+            self.data = None
+            if process is not None and process.returncode is None:
+                with suppress(TypeError, ProcessLookupError):
+                    process.kill()
+            raise
         except FileNotFoundError:
             _LOGGER.error("arping command not found. Please install iputils-arping package")
             self.is_alive = False

--- a/custom_components/device_pulse/coordinator.py
+++ b/custom_components/device_pulse/coordinator.py
@@ -74,6 +74,15 @@ class DevicePingCoordinator(DataUpdateCoordinator[PingResult]):
         self._log_level_failed_pings = log_level_failed_pings
         self._log_level_device_offline = log_level_device_offline
 
+        # Backoff handling: once a device has been failing for more than
+        # ping_attempts_before_failure consecutive polls we slow the polling
+        # down (up to ping_interval * backoff_max_factor) instead of spawning
+        # a subprocess at full rate forever. The interval is restored as soon
+        # as the device responds again.
+        self._backoff_max_factor = 4
+        self._base_ping_interval_ms = ping_interval * 1000
+        self._active_backoff_factor = 1
+
         # Remove unnecessary logs from inner coordinator methods
         if _LOGGER.isEnabledFor(logging.DEBUG):
             inner_logger = logging.getLogger(f"%s.inner" % __name__)
@@ -92,9 +101,6 @@ class DevicePingCoordinator(DataUpdateCoordinator[PingResult]):
     async def _async_update_data(self) -> PingResult:
         """Fetch data from ping."""
         await self.ping.async_update()
-
-        # Adjust the next update interval
-        self.update_interval = self._calculate_update_interval()
 
         is_alive = True
 
@@ -124,6 +130,15 @@ class DevicePingCoordinator(DataUpdateCoordinator[PingResult]):
             self.last_response_time = (
                 round(self.ping.data.get("avg"), 3) if self.ping.data else None
             )
+            # Device responded again: restore the base polling interval.
+            if self._active_backoff_factor != 1:
+                self._active_backoff_factor = 1
+                _LOGGER.info(
+                    "[%s] Device [%s][%s] back online, polling interval restored",
+                    self.integration.friendly_name,
+                    self.device_entry.name,
+                    self.ping.ip_address,
+                )
             _LOGGER.debug(
                 "[%s] Device [%s][%s] ping successful, response time: %sms",
                 self.integration.friendly_name,
@@ -138,6 +153,26 @@ class DevicePingCoordinator(DataUpdateCoordinator[PingResult]):
             self.failed_pings += 1
             self.total_failed_pings += 1
             self.last_response_time = None
+
+            # Once the failure threshold has been exceeded, slow the polling
+            # down instead of spawning a subprocess at full rate forever. The
+            # interval grows linearly with the number of extra consecutive
+            # failures up to ping_interval * backoff_max_factor.
+            if self.failed_pings > self.ping_attempts_before_failure:
+                extra = self.failed_pings - self.ping_attempts_before_failure
+                factor = min(extra + 1, self._backoff_max_factor)
+                if factor != self._active_backoff_factor:
+                    self._active_backoff_factor = factor
+                    _LOGGER.log(
+                        self._log_level_failed_pings,
+                        "[%s] Device [%s][%s] slowing down polling "
+                        "(interval x%d) after %d consecutive failures",
+                        self.integration.friendly_name,
+                        self.device_entry.name,
+                        self.ping.ip_address,
+                        factor,
+                        self.failed_pings,
+                    )
 
             _LOGGER.log(
                 self._log_level_failed_pings,
@@ -199,6 +234,9 @@ class DevicePingCoordinator(DataUpdateCoordinator[PingResult]):
         if self._first_update:
             self._first_update = False
 
+        # Adjust the next update interval based on the current backoff state.
+        self.update_interval = self._calculate_update_interval()
+
         return PingResult(
             is_alive=is_alive,
             ip_address=self.ping.ip_address,
@@ -225,9 +263,14 @@ class DevicePingCoordinator(DataUpdateCoordinator[PingResult]):
         })
 
     def _calculate_update_interval(self) -> timedelta:
-        """Calculate next update interval with jitter to distribute requests evenly."""
-        variation = self.ping_interval * 0.05  # 5% variation
-        jittered_interval = self.ping_interval + random.uniform(-variation, variation)
+        """Calculate next update interval with jitter to distribute requests evenly.
+
+        When the device has been failing for more than the failure threshold,
+        the base interval is multiplied by the active backoff factor.
+        """
+        base_interval = self._base_ping_interval_ms * self._active_backoff_factor
+        variation = base_interval * 0.05  # 5% variation
+        jittered_interval = base_interval + random.uniform(-variation, variation)
 
         return timedelta(milliseconds=jittered_interval)
 

--- a/custom_components/device_pulse/manifest.json
+++ b/custom_components/device_pulse/manifest.json
@@ -9,5 +9,5 @@
   "documentation": "https://github.com/studiobts/home-assistant-device-pulse",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/studiobts/home-assistant-device-pulse/issues",
-  "version": "1.8.1"
+  "version": "1.8.2"
 }

--- a/custom_components/device_pulse/network_status/all_devices_online.py
+++ b/custom_components/device_pulse/network_status/all_devices_online.py
@@ -52,7 +52,7 @@ class AllDevicesOnlineStatusSensor(BinarySensorEntity, NetworkStatusEntity):
         # device offline, in this case we have to do a full update in order to
         # be sure that all monitored device are online before change status
         elif state == "on" and self._attr_is_on:
-            self.hass.async_create_task(self._update())
+            self._async_schedule_update()
 
     async def _update(self) -> None:
         """Update the status based on all ping sensors."""

--- a/custom_components/device_pulse/network_status/base.py
+++ b/custom_components/device_pulse/network_status/base.py
@@ -35,15 +35,26 @@ class NetworkStatusEntity(Entity, ABC):
         self.hass = hass
         self.config_entry: ConfigEntry | None = config_entry
         self.integration: IntegrationData = config_entry.runtime_data.integration if config_entry else None
+        # Track a single in-flight _update task per entity so bursts of events
+        # (e.g. mass entity registry churn during a reload/restart) do not pile
+        # up one task per event.
+        self._update_task: asyncio.Task | None = None
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks when entity is added."""
 
         async def initial_update() -> None:
             await asyncio.sleep(5)
-            await self._update()
+            self._async_schedule_update()
 
-        self.hass.async_create_task(initial_update())
+        # Track the initial update so it is cancelled when the entity is
+        # removed during an unload/reload.
+        initial_update_task = self.hass.async_create_task(initial_update())
+
+        def cancel_initial_update() -> None:
+            initial_update_task.cancel()
+
+        self.async_on_remove(cancel_initial_update)
 
         self.async_on_remove(
             self.hass.bus.async_listen(
@@ -59,6 +70,35 @@ class NetworkStatusEntity(Entity, ABC):
             )
         )
 
+        # Make sure a pending _update task does not outlive the entity when it
+        # is removed during an unload/reload.
+        self.async_on_remove(self._async_cancel_update_task)
+
+    @callback
+    def _async_cancel_update_task(self) -> None:
+        """Cancel a pending update task, if any."""
+        if self._update_task is not None:
+            self._update_task.cancel()
+            self._update_task = None
+
+    @callback
+    def _async_schedule_update(self) -> None:
+        """Schedule a single _update run.
+
+        If an update is already scheduled or in-flight, this is a no-op to
+        coalesce bursts of events into a single run.
+        """
+        if self._update_task is not None and not self._update_task.done():
+            return
+
+        self._update_task = self.hass.async_create_task(self._async_run_update())
+
+    async def _async_run_update(self) -> None:
+        """Run _update and clear the task reference when done."""
+        try:
+            await self._update()
+        finally:
+            self._update_task = None
 
     @callback
     def _entity_registry_updated(self, event: Event) -> None:
@@ -80,12 +120,12 @@ class NetworkStatusEntity(Entity, ABC):
                     action,
                     entity_id,
                 )
-                self.hass.async_create_task(self._update())
+                self._async_schedule_update()
         elif action == "remove":
             _LOGGER.debug(
                 "Entity Registry event [%s] for [%s], updating count", action, entity_id
             )
-            self.hass.async_create_task(self._update())
+            self._async_schedule_update()
 
     @abstractmethod
     @callback

--- a/custom_components/device_pulse/network_status/total_devices_disconnected_count.py
+++ b/custom_components/device_pulse/network_status/total_devices_disconnected_count.py
@@ -60,7 +60,7 @@ class TotalDevicesDisconnectedCountSensor(SensorEntity, NetworkStatusEntity):
             if self.config_entry.entry_id != entity_entry.config_entry_id:
                 return
 
-        self.hass.async_create_task(self._update())
+        self._async_schedule_update()
 
     async def _update(self) -> None:
         """Update the count of offline devices."""

--- a/custom_components/device_pulse/ping_clients.py
+++ b/custom_components/device_pulse/ping_clients.py
@@ -1,0 +1,129 @@
+"""Ping clients for Device Pulse.
+
+The built-in Home Assistant ping clients only kill their child `ping`
+process when the probe times out. When the surrounding refresh task gets
+cancelled - which is exactly what the config entry machinery does on
+unload/reload/shutdown - the `ping` child process is orphaned and keeps
+running until it exits by itself.
+
+This module provides a drop-in replacement for `PingDataSubProcess` that
+reaps the child process on cancellation too.
+"""
+
+import asyncio
+from contextlib import suppress
+import logging
+import re
+from typing import Any
+
+from homeassistant.components.ping.helpers import PingDataSubProcess
+
+_LOGGER = logging.getLogger(__name__)
+
+# Overall timeout for the ping binary, in seconds (matches core ping).
+PING_TIMEOUT = 3
+
+PING_MATCHER = re.compile(
+    r"(?P<min>\d+.\d+)\/(?P<avg>\d+.\d+)\/(?P<max>\d+.\d+)\/(?P<mdev>\d+.\d+)"
+)
+
+PING_MATCHER_BUSYBOX = re.compile(
+    r"(?P<min>\d+.\d+)\/(?P<avg>\d+.\d+)\/(?P<max>\d+.\d+)"
+)
+
+WIN32_PING_MATCHER = re.compile(r"(?P<min>\d+)ms.+(?P<max>\d+)ms.+(?P<avg>\d+)ms")
+
+
+class ReapingPingDataSubProcess(PingDataSubProcess):
+    """PingDataSubProcess that kills the ping child on cancellation.
+
+    Identical behaviour to the core class but it also reaps the child when
+    the task is cancelled (config entry unload/reload or shutdown), so no
+    orphaned `ping` processes are left behind during a reload.
+    """
+
+    async def async_ping(self) -> dict[str, Any] | None:
+        """Send ICMP echo request and return details if success."""
+        _LOGGER.debug(
+            "Pinging %s with: `%s`", self.ip_address, " ".join(self._ping_cmd)
+        )
+
+        pinger = await asyncio.create_subprocess_exec(
+            *self._ping_cmd,
+            stdin=None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            close_fds=False,  # required for posix_spawn
+        )
+        try:
+            async with asyncio.timeout(self._count + PING_TIMEOUT):
+                out_data, out_error = await pinger.communicate()
+
+            if out_data:
+                _LOGGER.debug(
+                    "Output of command: `%s`, return code: %s:\n%s",
+                    " ".join(self._ping_cmd),
+                    pinger.returncode,
+                    out_data,
+                )
+            if out_error:
+                _LOGGER.debug(
+                    "Error of command: `%s`, return code: %s:\n%s",
+                    " ".join(self._ping_cmd),
+                    pinger.returncode,
+                    out_error,
+                )
+
+            if pinger.returncode and pinger.returncode > 1:
+                # returncode of 1 means the host is unreachable
+                _LOGGER.exception(
+                    "Error running command: `%s`, return code: %s",
+                    " ".join(self._ping_cmd),
+                    pinger.returncode,
+                )
+
+            if "max/" not in str(out_data):
+                match = PING_MATCHER_BUSYBOX.search(
+                    str(out_data).rsplit("\n", maxsplit=1)[-1]
+                )
+                if match is None:
+                    _LOGGER.debug("Could not parse ping output for %s", self.ip_address)
+                    return None
+                rtt_min, rtt_avg, rtt_max = match.groups()
+                return {"min": rtt_min, "avg": rtt_avg, "max": rtt_max}
+            match = PING_MATCHER.search(str(out_data).rsplit("\n", maxsplit=1)[-1])
+            if match is None:
+                _LOGGER.debug("Could not parse ping output for %s", self.ip_address)
+                return None
+            rtt_min, rtt_avg, rtt_max, rtt_mdev = match.groups()
+        except TimeoutError:
+            _LOGGER.debug(
+                "Timed out running command: `%s`, after: %s",
+                " ".join(self._ping_cmd),
+                self._count + PING_TIMEOUT,
+            )
+            await self._kill(pinger)
+            return None
+        except asyncio.CancelledError:
+            # Refresh task cancelled (unload/reload/shutdown): reap the child
+            # process instead of leaking it until it exits by itself.
+            await self._kill(pinger)
+            raise
+        except AttributeError as err:
+            _LOGGER.debug("Error matching ping output: %s", err)
+            return None
+        return {"min": rtt_min, "avg": rtt_avg, "max": rtt_max, "mdev": rtt_mdev}
+
+    async def async_update(self) -> None:
+        """Retrieve the latest details from the host."""
+        self.data = await self.async_ping()
+        self.is_alive = self.data is not None
+
+    async def _kill(self, pinger: asyncio.subprocess.Process | None) -> None:
+        """Best-effort kill and reap of a subprocess."""
+        if pinger is None or pinger.returncode is not None:
+            return
+        with suppress(TypeError, ProcessLookupError):
+            pinger.kill()
+        with suppress(TypeError):
+            await pinger.wait()


### PR DESCRIPTION
## Problem

When a config entry reload starts (device registry change, integration reload, core restart) the integration leaked resources every cycle:

1. **Orphaned ping/arping child processes.** The core `PingDataSubProcess` helper only kills its child when the probe *times out*. When the surrounding refresh task is cancelled - exactly what the config entry machinery does on unload/reload/shutdown - the `ping` child is orphaned and keeps running until it exits by itself. `PingDataARP` never killed its child on cancellation either. On a busy integration this can leave many stray processes per reload.

2. **Runaway tasks.** The delayed reload task created from `_device_registry_updated` was a bare `hass.async_create_task` (the core cannot cancel it on unload) and was cancelled fire-and-forget without awaiting. The `network_status` entities also spawned a raw `_update()` task for *every* entity-registry event, piling up tasks during the mass registry churn that accompanies a reload.

3. **No backoff.** Once a device exceeded the failure threshold it was flagged OFFLINE but kept being polled at the full rate forever (the log kept counting N/M with N > M), spawning a subprocess every interval 24/7.

## Changes

- **ping_clients.py (new)** - `ReapingPingDataSubProcess`, a drop-in replacement for `PingDataSubProcess` that kills and awaits the child on `CancelledError` too (not only on timeout). Used for subprocess pings.
- **arping.py** - kill and reap the `arping` child on timeout *and* on cancellation.
- **__init__.py** - schedule the delayed reload as a config-entry background task (core cancels it on unload), guard it against firing when the entry is no longer `LOADED` or HA is stopping, and cancel + await any pending reload task in `async_unload_entry`.
- **network_status/* -** coalesce entity updates into a single tracked task per entity and cancel it on entity removal; the initial update is cancellable too.
- **coordinator.py** - once the failure threshold is exceeded, grow the polling interval linearly with extra consecutive failures up to `ping_interval * 4`, and restore the base interval as soon as the device answers again.

## Testing

Validated on Home Assistant 2026.9.1:
- With a device unreachable: interval grows 5s -> 10s -> 15s -> 20s (capped), then stays there.
- When the device returns, `failed_pings` resets to 0 and the base interval is restored.
- 40 consecutive config-entry reloads: no errors, no duplicate entities, no orphaned ping processes, RSS flat (second batch of 20 reloads: 0 MB growth).
- Repeated core restarts show memory going down, not up.

Relates to the environment described in issue #47 (icmplib vs subprocess ping path).
